### PR TITLE
Renamed local_ansible_data_path variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ maven_notifier_mirror: "http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-n
 # SHA256 sum for the redistributable package
 maven_notifier_redis_sha256sum: ed6fbb0bffc633cf43b4f52d8aae33ac1ce313f7528ca4aecaa75559f8a3bfd5
 
-# path for Ansible to store downloaded files
-local_ansible_data_path: '/tmp/ansible/data'
+# Directory to store files downloaded for Maven Notifier installation
+maven_notifier_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,4 +9,4 @@ maven_notifier_mirror: "http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-n
 maven_notifier_maven_home: "{{ ansible_local.maven.general.maven_home }}"
 
 # path for Ansible to store downloaded files
-local_ansible_data_path: '/tmp/ansible/data'
+maven_notifier_download_dir: '/tmp/ansible/data'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,16 +10,16 @@
     that:
       - "maven_notifier_redis_sha256sum not in (None, '')"
 
-- name: Create local Ansible data directory
+- name: Create download directory
   file:
     state: directory
     mode: 'u=rwx,go=rx'
-    dest: "{{ local_ansible_data_path }}"
+    dest: "{{ maven_notifier_download_dir }}"
 
 - name: Download Maven Notifier
   get_url:
     url: "{{ maven_notifier_mirror }}/{{ maven_notifier_redis_filename }}"
-    dest: "{{ local_ansible_data_path }}/{{ maven_notifier_redis_filename }}"
+    dest: "{{ maven_notifier_download_dir }}/{{ maven_notifier_redis_filename }}"
     sha256sum: "{{ maven_notifier_redis_sha256sum }}"
     force: false
     use_proxy: true
@@ -29,7 +29,7 @@
 - name: Install Maven Notifier
   become: yes
   copy:
-    src: "{{ local_ansible_data_path }}/{{ maven_notifier_redis_filename }}"
+    src: "{{ maven_notifier_download_dir }}/{{ maven_notifier_redis_filename }}"
     remote_src: yes
     dest: "{{ maven_notifier_maven_home }}/lib/ext/{{ maven_notifier_redis_filename }}"
     owner: root


### PR DESCRIPTION
Renamed local_ansible_data_path to maven_notifier_download_dir as it was potentially misleading.

Enhancement: resolves #7
