### PR TITLE
Moved default maven_notifier_download_dir under user home

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ maven_notifier_mirror: "http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-n
 maven_notifier_redis_sha256sum: ed6fbb0bffc633cf43b4f52d8aae33ac1ce313f7528ca4aecaa75559f8a3bfd5
 
 # Directory to store files downloaded for Maven Notifier installation
-maven_notifier_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"
+maven_notifier_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,4 +9,4 @@ maven_notifier_mirror: "http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-n
 maven_notifier_maven_home: "{{ ansible_local.maven.general.maven_home }}"
 
 # Directory to store files downloaded for Maven Notifier installation
-maven_notifier_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"
+maven_notifier_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"


### PR DESCRIPTION
Changed default for `maven_notifier_download_dir` from `/tmp/ansible/data` to `~/.ansible/tmp/downloads`.

Enhancement: resolves #8
