### PR TITLE
Updated default value for maven_home

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ are shown below):
 maven_notifier_version: 1.9.1
 
 # Location of the Maven installation to add the Maven Notifier extension to.
-maven_notifier_maven_home: "{{ ansible_local.maven.general.maven_home }}"
+maven_notifier_maven_home: "{{ ansible_local.maven.general.home }}"
 
 # Mirror where to dowload Maven Notifier redistributable package from.
 maven_notifier_mirror: "http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-notifier/{{ maven_notifier_version }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ maven_notifier_version: 1.9.1
 maven_notifier_mirror: "http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-notifier/{{ maven_notifier_version }}"
 
 # Location of the Maven installation to add the Maven Notifier extension to.
-maven_notifier_maven_home: "{{ ansible_local.maven.general.maven_home }}"
+maven_notifier_maven_home: "{{ ansible_local.maven.general.home }}"
 
 # Directory to store files downloaded for Maven Notifier installation
 maven_notifier_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: gantsign.maven
-  version: '2.0.1'
+  version: '3.0.0'


### PR DESCRIPTION
Changed to match fact in version 3.0.0 of gantsign.maven.

Enhancement: resolves #13
