### PR TITLE
Adopted yes|no convention for booleans

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,9 +21,9 @@
     url: "{{ maven_notifier_mirror }}/{{ maven_notifier_redis_filename }}"
     dest: "{{ maven_notifier_download_dir }}/{{ maven_notifier_redis_filename }}"
     sha256sum: "{{ maven_notifier_redis_sha256sum }}"
-    force: false
-    use_proxy: true
-    validate_certs: true
+    force: no
+    use_proxy: yes
+    validate_certs: yes
     mode: 'u=rw,go=r'
 
 - name: install Maven Notifier


### PR DESCRIPTION
Ansible supports `true|false` and `yes|no` (with varying case) for boolean values; the Ansible documentation is wildly inconsistent on which it uses, so it's easy to end up with a mixture.

It's better to be consistent, so `yes|no` is now the convention for all Ansible roles written by GantSign.
