### PR TITLE
Specify hosts to testinfa via python

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -22,6 +22,3 @@ docker:
   - name: ansible-role-maven-notifier-01
     image: ubuntu
     image_version: '16.04'
-
-testinfra:
-  hosts: ansible-role-maven-notifier-01

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,3 +1,8 @@
+from testinfra.utils.ansible_runner import AnsibleRunner
+
+testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
+
+
 def test_maven_notifier(Command):
     assert Command("mvn help:help").rc == 0
 


### PR DESCRIPTION
Was specifying hosts via molecule.yml file. The new approach is dynamic and avoids repeating configuration information.
