### PR TITLE
Switched to single quotes for YAML strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ are shown below):
 maven_notifier_version: '1.9.1'
 
 # Location of the Maven installation to add the Maven Notifier extension to.
-maven_notifier_maven_home: "{{ ansible_local.maven.general.home }}"
+maven_notifier_maven_home: '{{ ansible_local.maven.general.home }}'
 
 # Mirror where to dowload Maven Notifier redistributable package from.
-maven_notifier_mirror: "http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-notifier/{{ maven_notifier_version }}"
+maven_notifier_mirror: 'http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-notifier/{{ maven_notifier_version }}'
 
 # Directory to store files downloaded for Maven Notifier installation
 maven_notifier_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,10 +3,10 @@
 maven_notifier_version: '1.9.1'
 
 # Mirror where to dowload Maven Notifier redistributable package from.
-maven_notifier_mirror: "http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-notifier/{{ maven_notifier_version }}"
+maven_notifier_mirror: 'http://dl.bintray.com/jcgay/maven/fr/jcgay/maven/maven-notifier/{{ maven_notifier_version }}'
 
 # Location of the Maven installation to add the Maven Notifier extension to.
-maven_notifier_maven_home: "{{ ansible_local.maven.general.home }}"
+maven_notifier_maven_home: '{{ ansible_local.maven.general.home }}'
 
 # Directory to store files downloaded for Maven Notifier installation
 maven_notifier_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: load version vars
   with_first_found:
-    - "../vars/versions/{{ maven_notifier_version }}.yml"
+    - '../vars/versions/{{ maven_notifier_version }}.yml'
     - ../vars/versions/default.yml
-  include_vars: "{{ item }}"
+  include_vars: '{{ item }}'
 
 - name: assert version vars
   assert:
@@ -14,13 +14,13 @@
   file:
     state: directory
     mode: 'u=rwx,go=rx'
-    dest: "{{ maven_notifier_download_dir }}"
+    dest: '{{ maven_notifier_download_dir }}'
 
 - name: download Maven Notifier
   get_url:
-    url: "{{ maven_notifier_mirror }}/{{ maven_notifier_redis_filename }}"
-    dest: "{{ maven_notifier_download_dir }}/{{ maven_notifier_redis_filename }}"
-    sha256sum: "{{ maven_notifier_redis_sha256sum }}"
+    url: '{{ maven_notifier_mirror }}/{{ maven_notifier_redis_filename }}'
+    dest: '{{ maven_notifier_download_dir }}/{{ maven_notifier_redis_filename }}'
+    sha256sum: '{{ maven_notifier_redis_sha256sum }}'
     force: no
     use_proxy: yes
     validate_certs: yes
@@ -29,9 +29,9 @@
 - name: install Maven Notifier
   become: yes
   copy:
-    src: "{{ maven_notifier_download_dir }}/{{ maven_notifier_redis_filename }}"
+    src: '{{ maven_notifier_download_dir }}/{{ maven_notifier_redis_filename }}'
     remote_src: yes
-    dest: "{{ maven_notifier_maven_home }}/lib/ext/{{ maven_notifier_redis_filename }}"
+    dest: '{{ maven_notifier_maven_home }}/lib/ext/{{ maven_notifier_redis_filename }}'
     owner: root
     group: root
     mode: 'u=rw,go=r'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 # filename of Maven Notifier redistributable package
-maven_notifier_redis_filename: "maven-notifier-{{ maven_notifier_version }}-shaded.jar"
+maven_notifier_redis_filename: 'maven-notifier-{{ maven_notifier_version }}-shaded.jar'


### PR DESCRIPTION
Switched to single quotes (rather than double quotes) for YAML strings where escaping isn't required.