### PR TITLE
Changed example role to pure YAML syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Example Playbook
 ```yaml
 - hosts: servers
   roles:
-     - { role: gantsign.maven-notifier, maven_notifier_maven_home: /opt/maven/apache-maven-3.3.9 }
+    - role: gantsign.maven-notifier
+      maven_notifier_maven_home: /opt/maven/apache-maven-3.3.9
 ```
 
 Related Roles


### PR DESCRIPTION
Using the hybrid YAML/JSON syntax is potentially confusing to new users as it's not clear whether this peculiar syntax is a requirement or not.