### PR TITLE
Changed test to use host fixture

### DIFF
--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -6,10 +6,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_maven_notifier(Command):
-    assert Command("mvn help:help").rc == 0
+def test_maven_notifier(host):
+    assert host.run("mvn help:help").rc == 0
 
     # Check Maven Notifier installed
-    cmd = Command("find /opt/maven/apache-maven-3.3.9 | grep --color=never %s",
-                  "lib/ext/maven-notifier-")
-    assert cmd.rc == 0
+    cmd = "find /opt/maven/apache-maven-3.3.9 | grep --color=never %s"
+    assert host.run(cmd, "lib/ext/maven-notifier-").rc == 0


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.