### PR TITLE
Fixed test for Debian 9

### DIFF
--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -7,7 +7,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 def test_maven_notifier(host):
-    assert host.run("mvn help:help").rc == 0
+    cmd = "mvn '-Djavax.accessibility.assistive_technologies= ' help:help"
+    assert host.run(cmd).rc == 0
 
     # Check Maven Notifier installed
     cmd = "find /opt/maven/apache-maven-3.3.9 | grep --color=never %s"


### PR DESCRIPTION
Seems to be missing a Java dependency for assistive technologies.