### PR TITLE
Upgraded minimum CentOS  version to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Requirements
 
         * CentOS
 
-            * 6
+            * 7
             * 8
 
         * Fedora

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 6
+        - 7
         - 8
     - name: Fedora
       versions:

--- a/molecule/centos-min/molecule.yml
+++ b/molecule/centos-min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-maven-notifier-centos-min
-    image: centos:6
+    image: centos:7
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
CentOS ended support for 6 on 2020-11-30.