### PR TITLE
Increased upper Debian test version to Bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Requirements
 
             * Jessie (8)
             * Stretch (9)
+            * Buster (10)
+            * Bullseye (11)
 
         * Ubuntu
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,6 +24,8 @@ galaxy_info:
       versions:
         - stretch
         - jessie
+        - buster
+        - bullseye
   galaxy_tags:
     - maven
     - ubuntu

--- a/molecule/debian-max/converge.yml
+++ b/molecule/debian-max/converge.yml
@@ -9,10 +9,10 @@
       changed_when: no
 
     # Travis CI doesn't provide all the Debian dependencies for the full JDK.
-    - name: install jre-headless 8
+    - name: install jre-headless 11
       become: yes
       apt:
-        name: openjdk-8-jre-headless
+        name: openjdk-11-jre-headless
         state: present
 
   roles:

--- a/molecule/debian-max/molecule.yml
+++ b/molecule/debian-max/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-maven-notifier-debian-max
-    image: debian:9
+    image: debian:11
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Bullseye is the latest stable version of Debian.