### PR TITLE
Dropped support for Debian Jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Requirements
 
         * Debian
 
-            * Jessie (8)
             * Stretch (9)
             * Buster (10)
             * Bullseye (11)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,7 +23,6 @@ galaxy_info:
     - name: Debian
       versions:
         - stretch
-        - jessie
         - buster
         - bullseye
   galaxy_tags:

--- a/molecule/debian-min/converge.yml
+++ b/molecule/debian-min/converge.yml
@@ -2,9 +2,19 @@
 - name: Converge
   hosts: all
 
+  pre_tasks:
+    - name: update apt cache
+      apt:
+        update_cache: yes
+      changed_when: no
+
+    - name: install jre-headless 8
+      become: yes
+      apt:
+        name: openjdk-8-jre-headless
+        state: present
+
   roles:
-    - role: gantsign.java
-      java_version: '8'
     - role: gantsign.maven
       maven_version: '3.3.9'
       maven_install_dir: /opt/maven

--- a/molecule/debian-min/molecule.yml
+++ b/molecule/debian-min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-maven-notifier-debian-min
-    image: debian:8
+    image: debian:9
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:

--- a/molecule/debian-min/requirements.yml
+++ b/molecule/debian-min/requirements.yml
@@ -1,5 +1,3 @@
 ---
-- src: gantsign.java
-  version: '8.0.0'
 - src: gantsign.maven
   version: '5.2.0'


### PR DESCRIPTION
Debian ended LTS support in June 2020.