### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Requirements
 
         * Ubuntu
 
-            * Xenial (16.04)
             * Bionic (18.04)
             * Focal (20.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,6 @@ galaxy_info:
         - 15.3
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
     - name: Debian

--- a/molecule/ubuntu-min/converge.yml
+++ b/molecule/ubuntu-min/converge.yml
@@ -3,20 +3,16 @@
   hosts: all
 
   pre_tasks:
-    - name: install OpenJDK PPA
-      apt_repository:
-        repo: ppa:openjdk-r/ppa
+    - name: update apt cache
+      apt:
+        update_cache: yes
+      changed_when: no
 
     - name: install jdk 8
       become: yes
       apt:
         name: openjdk-8-jdk
         state: present
-
-    - name: update ca-certificates
-      become: yes
-      command: update-ca-certificates --fresh
-      changed_when: no
 
   roles:
     - role: gantsign.maven

--- a/molecule/ubuntu-min/molecule.yml
+++ b/molecule/ubuntu-min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-maven-notifier-ubuntu-min
-    image: ubuntu:16.04
+    image: ubuntu:18.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.